### PR TITLE
Remove all images from the post listing

### DIFF
--- a/blog/posts/dbi-3-1.qmd
+++ b/blog/posts/dbi-3-1.qmd
@@ -77,7 +77,7 @@ following topics:
 After completing the process, projects are entitled to wear a badge like
 the one below for the DBI project:
 
-[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/1882/badge)](https://bestpractices.coreinfrastructure.org/projects/1882)
+[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/1882/badge.svg)](https://bestpractices.coreinfrastructure.org/projects/1882)
 
 A click on the badge takes you to the detailed assessment. In addition
 to the badge, completing the self-certification allows the maintainer to

--- a/index.qmd
+++ b/index.qmd
@@ -17,6 +17,7 @@ listing:
   - id: blog
     contents: blog/posts
     type: default
+    fields: [title, subtitle, author, description, date]
     sort: 
       - "date desc"
       - "title asc"


### PR DESCRIPTION
Fix #1 

I followed https://quarto.org/docs/websites/website-listings.html#customizing-fields

![image](https://github.com/cynkra/rdbidotorg/assets/8360597/22704632-e3b4-4b7b-b9c0-71b3abf723f4)

I also added an extension to the badge to that it might appear.

![image](https://github.com/cynkra/rdbidotorg/assets/8360597/96985444-7561-4870-9c9a-a0cef79be9af)
