### PR TITLE
Update URLs to use HTTPS and fix broken/outdated links

### DIFF
--- a/blog/dbi-3-1/index.qmd
+++ b/blog/dbi-3-1/index.qmd
@@ -19,7 +19,7 @@ I'm grateful for the trust, and will do my best to make the "Maintaining
 DBI" project a success. For this round, the main goals are: maintain,
 enhance, disseminate. The project is delayed mostly becase I grossly
 underestimated how much time and energy it would take to set up
-[cynkra](http://cynkra.com). The new joint venture with Christoph Sax
+[cynkra](https://cynkra.com). The new joint venture with Christoph Sax
 consults businesses and organizations on matters related to R,
 statistics, data, and software. We are strongly committed to R and
 open-source software, and more priority will be given the "Maintaining
@@ -36,13 +36,13 @@ Presentations at meetups
 ------------------------
 
 I presented DBI at the [Berlin R user
-group](https://www.meetup.com/Berlin-R-Users-Group/), at the
+group](https://www.meetup.com/berlin-r-users-group/), at the
 amstRdays, and at the [Zurich R
 meetup](https://zurich-r-user-group.github.io/index.html). The
 presentation in Berlin made me realize that a progress report isn't that
 helpful for a general audience. The Zurich version of the presentation
 featured a DBI intro also suitable for new users, merely highlighting
-recent developments. [These slides](https://bit.ly/2wFJix3), and the
+recent developments. [These slides](https://krlmlr.github.io/dbi-slides/2018-09-zurich-meetup/), and the
 [intro at db.rstudio.com](https://solutions.posit.co/connections/db/r-packages/dbi/) seem to be the
 most recent general-purpose introduction materials available. I think an
 entry-level tutorial would be a good fit for a DBI vignette.
@@ -51,7 +51,7 @@ CII badge
 ---------
 
 From
-<a href="https://bestpractices.coreinfrastructure.org/en" class="uri">https://bestpractices.coreinfrastructure.org/en</a>:
+<a href="https://www.bestpractices.dev/en" class="uri">https://www.bestpractices.dev/en</a>:
 
 > The Linux Foundation (LF) Core Infrastructure Initiative (CII) Best
 > Practices badge is a way for Free/Libre and Open Source Software
@@ -77,7 +77,7 @@ following topics:
 After completing the process, projects are entitled to wear a badge like
 the one below for the DBI project:
 
-[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/1882/badge.svg)](https://bestpractices.coreinfrastructure.org/projects/1882)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/1882/badge.svg)](https://www.bestpractices.dev/en/projects/1882/passing)
 
 A click on the badge takes you to the detailed assessment. In addition
 to the badge, completing the self-certification allows the maintainer to
@@ -151,7 +151,7 @@ repeated below, with comments based on experience from the past year.
     data import.
 
     -   The new [*arkdb*
-        package](https://cran.r-project.org/package=arkdb) offers a
+        package](https://cran.r-project.org/web/packages/arkdb/index.html) offers a
         dedicated interface for importing data, I still think this
         functionality should better live there (or elsewhere).
 
@@ -258,11 +258,11 @@ New packages worth reviewing include:
 
 -   [*arkdb*](https://cran.r-project.org/package=arkdb): Consistent (and
     fast?) import and export
--   [*flobr*](https://cran.r-project.org/package=flobr): Converting
+-   [*flobr*](https://cran.r-project.org/web/packages/flobr/index.html): Converting
     files to blobs and back
 -   [*sqlr*](https://github.com/nbenn/sqlr): SQLAlchemy-like DSL for
     data definition, work in progress
--   [*dbplot*](https://cran.r-project.org/package=dbplot): Plotting from
+-   [*dbplot*](https://cran.r-project.org/web/packages/dbplot/index.html): Plotting from
     the database
 -   and many others.
 
@@ -272,8 +272,8 @@ more consistent appearance of the entire project.
 As a New Year's resolution, I pledge to do a better job as package
 maintainer for *DBI* and related packages. I reserved a few hours each
 Monday to respond to issues raised on GitHub and other channels
-([SO](https://stackoverflow.com/), [RStudio
-Community](https://community.rstudio.com/), Twitter, and the somewhat
+([SO](https://stackoverflow.com/questions), [RStudio
+Community](https://forum.posit.co/), Twitter, and the somewhat
 underappreciated [R-SIG-DB mailing
 list](https://stat.ethz.ch/mailman/listinfo/r-sig-db)). CI builds on
 Travis and AppVeyor also require occasional intervention. The remaining

--- a/blog/dbi-3-1/index.qmd
+++ b/blog/dbi-3-1/index.qmd
@@ -42,7 +42,7 @@ meetup](https://zurich-r-user-group.github.io/index.html). The
 presentation in Berlin made me realize that a progress report isn't that
 helpful for a general audience. The Zurich version of the presentation
 featured a DBI intro also suitable for new users, merely highlighting
-recent developments. [These slides](https://krlmlr.github.io/dbi-slides/2018-09-zurich-meetup/), and the
+recent developments. [These slides](https://bit.ly/2wFJix3), and the
 [intro at db.rstudio.com](https://solutions.posit.co/connections/db/r-packages/dbi/) seem to be the
 most recent general-purpose introduction materials available. I think an
 entry-level tutorial would be a good fit for a DBI vignette.
@@ -151,7 +151,7 @@ repeated below, with comments based on experience from the past year.
     data import.
 
     -   The new [*arkdb*
-        package](https://cran.r-project.org/web/packages/arkdb/index.html) offers a
+        package](https://cran.r-project.org/package=arkdb) offers a
         dedicated interface for importing data, I still think this
         functionality should better live there (or elsewhere).
 
@@ -258,11 +258,11 @@ New packages worth reviewing include:
 
 -   [*arkdb*](https://cran.r-project.org/package=arkdb): Consistent (and
     fast?) import and export
--   [*flobr*](https://cran.r-project.org/web/packages/flobr/index.html): Converting
+-   [*flobr*](https://cran.r-project.org/package=flobr): Converting
     files to blobs and back
 -   [*sqlr*](https://github.com/nbenn/sqlr): SQLAlchemy-like DSL for
     data definition, work in progress
--   [*dbplot*](https://cran.r-project.org/web/packages/dbplot/index.html): Plotting from
+-   [*dbplot*](https://cran.r-project.org/package=dbplot): Plotting from
     the database
 -   and many others.
 

--- a/blog/dbi-3-2/index.qmd
+++ b/blog/dbi-3-2/index.qmd
@@ -173,7 +173,7 @@ logging code for debugging.
 
 This also works in scenarios where DBI is used under the hood by other
 packages like [dbplyr](https://dbplyr.tidyverse.org/) or
-[tidypredict](https://tidymodels.github.io/tidypredict/). The log will
+[tidypredict](https://tidypredict.tidymodels.org/). The log will
 represent the DBI operations issued, which allows for a better
 understanding of the internals.
 
@@ -298,7 +298,7 @@ Now that using DBItest to test backends against custom infrastructure is
 understood, it becomes easier to enhance tests so that not only pristine
 setups are tested, but also databases with nonstandard settings for time
 zone, character encoding or collation.
-[Terraform](https://www.terraform.io/) helps automating the setup of
+[Terraform](https://developer.hashicorp.com/terraform) helps automating the setup of
 databases of different flavors on cloud providers such as Azure or
 Google Cloud. The desired state of computing infrastructure is specified
 in a declarative way. This allows testing a much broader variety of

--- a/blog/dbi-3-4/index.qmd
+++ b/blog/dbi-3-4/index.qmd
@@ -118,7 +118,7 @@ Code transformation was carried out in semi-automated fashion, with the help of 
 ## Future work
 
 The {DBI} package provides a low-level interface for database connectivity with a [narrow scope](https://www.r-dbi.org/blog/dbi-3-3.html).
-Data query and manipulation tasks that are not in-scope for {DBI} are currently left to auxiliary packages, including [dbplyr](https://dbplyr.tidyverse.org/), [dm](https://cynkra.github.io/dm/), [dbx](https://github.com/ankane/dbx) and [rquery](https://winvector.github.io/rquery/).
+Data query and manipulation tasks that are not in-scope for {DBI} are currently left to auxiliary packages, including [dbplyr](https://dbplyr.tidyverse.org/), [dm](https://dm.cynkra.com/), [dbx](https://github.com/ankane/dbx) and [rquery](https://winvector.github.io/rquery/).
 {DBI} uses S4, one of several systems for object-oriented programming in R.
 While S4 offers several advantages over its predecessor S3, including increased strictness and multiple dispatch, it also is more rigid compared to S3.
 <!-- I don't see how this is specific to S4, but then again, I haven't really used S4 myself, so I'm no expert; it might still be worthwhile to elaborate a bit here -->

--- a/blog/dbi-4-1/index.qmd
+++ b/blog/dbi-4-1/index.qmd
@@ -118,7 +118,7 @@ Examples include:
 
 - [adbcsqlite](https://arrow.apache.org/adbc/current/r/adbcsqlite/), on CRAN
 - [adbcpostgresql](https://arrow.apache.org/adbc/current/r/adbcpostgresql/), on CRAN
-- [adbcsnowflake](https://github.com/apache/arrow-adbc/tree/main/r/adbcsnowflake) for [Snowflake](https://www.snowflake.com/)
+- [adbcsnowflake](https://github.com/apache/arrow-adbc/tree/main/r/adbcsnowflake) for [Snowflake](https://www.snowflake.com/en/)
 - [adbcflightsql](https://github.com/apache/arrow-adbc/tree/main/r/adbcflightsql) for [FlightSQL](https://arrow.apache.org/docs/format/FlightSql.html)
 - [duckdb](https://duckdb.org/docs/api/r), which implements an ADBC driver in addition to the DBI backend
 

--- a/blog/rstudio-conf/index.qmd
+++ b/blog/rstudio-conf/index.qmd
@@ -7,14 +7,14 @@ description: "Presentation at rstudio::conf, San Diego"
 
 ## Link to video
 
-<p><a href="https://posit.co/resources/videos/connecting-to-open-source-databases/?wvideo=yf1vdwugk5"><img src="https://embed-ssl.wistia.com/deliveries/6cc6be1f7e21a6ecd6640c0068ecd86a94c235d0.jpg?image_play_button_size=2x&amp;image_crop_resized=960x540&amp;image_play_button=1&amp;image_play_button_color=4287c7e0" style="width: 400px; height: 225px;" width="400" height="225"></a></p><p><a href="https://posit.co/resources/videos/connecting-to-open-source-databases/?wvideo=yf1vdwugk5">Connecting to open source databases - Posit</a></p>
+<p><a href="https://posit.co/resources/videos/connecting-to-open-source-databases?wvideo=yf1vdwugk5"><img src="https://embed-ssl.wistia.com/deliveries/6cc6be1f7e21a6ecd6640c0068ecd86a94c235d0.jpg?image_play_button_size=2x&amp;image_crop_resized=960x540&amp;image_play_button=1&amp;image_play_button_color=4287c7e0" style="width: 400px; height: 225px;" width="400" height="225"></a></p><p><a href="https://posit.co/resources/videos/connecting-to-open-source-databases?wvideo=yf1vdwugk5">Connecting to open source databases - Posit</a></p>
 
 
 ## Slides
 
 <div style="position:relative;padding-top:56.25%;">
-  <iframe src="https://krlmlr.github.io/dbi-slides/2018-02-san-diego-rstudio-conf" frameborder="0" allowfullscreen
+  <iframe src="https://krlmlr.github.io/dbi-slides/2018-02-san-diego-rstudio-conf/" frameborder="0" allowfullscreen
     style="position:absolute;top:0;left:0;width:100%;height:100%;"></iframe>
 </div>
 
-<a href="https://krlmlr.github.io/dbi-slides/2018-02-san-diego-rstudio-conf" target="_blank">Full screen version</a>
+<a href="https://krlmlr.github.io/dbi-slides/2018-02-san-diego-rstudio-conf/" target="_blank">Full screen version</a>

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,8 +1,0 @@
-# Lychee link checker configuration
-
-[network]
-# Follow redirects and treat them as successful
-accept_redirect = true
-
-[output]
-# Display redirect information in reports

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,8 @@
+# Lychee link checker configuration
+
+[network]
+# Follow redirects and treat them as successful
+accept_redirect = true
+
+[output]
+# Display redirect information in reports


### PR DESCRIPTION
## Summary
This PR updates various URLs across blog posts to use HTTPS protocol and fixes broken or outdated links that have been moved to new domains.

## Key Changes
- **Protocol updates**: Changed `http://cynkra.com` to `https://cynkra.com`
- **Domain migrations**: 
  - Updated Core Infrastructure Initiative Best Practices URLs from `bestpractices.coreinfrastructure.org` to `www.bestpractices.dev`
  - Updated RStudio Community link from `community.rstudio.com` to `forum.posit.co`
  - Updated tidypredict documentation from `tidymodels.github.io/tidypredict/` to `tidypredict.tidymodels.org/`
  - Updated dm package documentation from `cynkra.github.io/dm/` to `dm.cynkra.com/`
  - Updated Terraform documentation from `terraform.io` to `developer.hashicorp.com/terraform`
  - Updated Snowflake URL to include language parameter `/en/`
- **URL path fixes**:
  - Fixed Berlin R user group meetup URL casing: `Berlin-R-Users-Group` to `berlin-r-users-group`
  - Updated Stack Overflow link to point to questions section
  - Fixed Posit video embed URLs by removing trailing slashes in query parameters
  - Added trailing slashes to iframe and link URLs for consistency
- **Badge link updates**: Updated OpenSSF Best Practices badge SVG and link URLs to new domain with `/en/projects/` path

## Notable Details
These changes ensure all external links are current and use secure HTTPS connections, improving both security and user experience when readers click through to referenced resources.

https://claude.ai/code/session_01Fo7gSLcLXSooTsPtNDcudC