### PR TITLE
Fix broken documentation URLs in package backend

### DIFF
--- a/backends/index.qmd
+++ b/backends/index.qmd
@@ -26,6 +26,20 @@ all_df <- jsonlite::fromJSON(all_json, flatten = TRUE)
 ```
 
 ```{r all-url, echo = FALSE, results='asis'}
+url_replacements <- c(
+  "http://developer.r-project.org/db" = "https://developer.r-project.org/db/",
+  "http://www.monetdb.org/" = "https://www.monetdb.org/",
+  "https://boto3.amazonaws.com/v1/documentation/api/latest/index.html" = "https://docs.aws.amazon.com/boto3/latest/",
+  "https://docs.databricks.com/api" = "https://docs.databricks.com/aws/en/reference/api",
+  "https://downloads.mariadb.org/connector-c/" = "https://mariadb.org/download/"
+)
+
+fix_url <- function(u) {
+  if (length(u) == 0) return(u)
+  replaced <- unname(url_replacements[u])
+  ifelse(is.na(replaced), u, replaced)
+}
+
 format_pkg <- function(name, version, title, description, date, maintainer, license, url, bugs) {
 
   if (is.na(date)) {
@@ -35,17 +49,19 @@ format_pkg <- function(name, version, title, description, date, maintainer, lice
   }
 
   if (length(url) > 0 && !anyNA(url)) {
+    url <- fix_url(url)
     name <- paste0("[", name, "](", url[[1]], ")")
     url <- url[-1]
   }
-  
+
   if (length(url) > 0 && !anyNA(url)) {
     url <- paste0(" [:link:](", url, ")", collapse = "")
   } else {
     url <- ""
   }
-  
+
   if (!is.na(bugs)) {
+    bugs <- fix_url(bugs)
     bugs <- paste0(" [:bug:](", bugs, ")")
   } else {
     bugs <- ""


### PR DESCRIPTION
## Summary
This PR fixes broken or outdated documentation URLs in the backends index by implementing URL replacement logic that maps old URLs to their current locations.

## Key Changes
- Added `url_replacements` mapping that corrects 5 broken/outdated URLs:
  - R project developer database (http → https with trailing slash)
  - MonetDB documentation (http → https)
  - AWS Boto3 documentation (updated to current docs.aws.amazon.com location)
  - Databricks API documentation (updated to AWS-specific reference path)
  - MariaDB connector downloads (updated to main download page)
- Implemented `fix_url()` helper function to apply URL replacements, handling edge cases like empty vectors and NA values
- Applied URL fixing to both package URLs and bug report URLs in the `format_pkg()` function
- Minor whitespace cleanup (removed trailing spaces)

## Implementation Details
The `fix_url()` function uses named vector lookup to replace URLs, returning the original URL if no replacement is found. This approach is efficient and maintainable for managing URL migrations over time.

https://claude.ai/code/session_0126r6Apq5YMd6yg9U9jE445