### PR TITLE
fix(lychee): ignore prestodb.io homepage (intermittent 403)

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -4,6 +4,7 @@ https://gitlab.com/hrbrmstr/sergeant
 https://gitlab.com/hrbrmstr/sergeant/-/issues
 https://www.mysql.com/
 https://www.oracle.com/
+https://prestodb.io/
 https://mtlynch.io/good-developers-bad-tests/
 https://voltrondata.com/
 https://medium.com/@kazushi/simulate-high-latency-network-using-docker-containerand-tc-commands-a3e503ea4307


### PR DESCRIPTION
## Problem

The `render` workflow has been failing intermittently on scheduled runs (the same `main` commit alternates success/failure across days). The failure is **not** in the R/Quarto render step — that step succeeds. The job fails at the **lychee Link Checker** step, which runs with `fail: true`:

```
[403] https://prestodb.io/ (at 369:227) | Rejected status code: 403 Forbidden

| 🚫 Errors      | 1     |
### Errors in docs/backends/index.html
* [403] <https://prestodb.io/> (at 369:227) | Rejected status code: 403 Forbidden
```

`https://prestodb.io/` intermittently returns `403 Forbidden` to lychee's automated requests (bot protection), which is why the workflow passes on some days and fails on others.

## Why this is the right fix

- The `prestodb.io` link is **valid** — the 403 is bot protection, not a broken link.
- The URL is **not in this repo's source**. `backends/index.qmd` fetches the backend list at render time from `https://r-dbi.github.io/backends/all.json`, so the URL cannot be corrected in-repo.
- The repository already handles this exact class of false-positive external links by listing them in `.lycheeignore` (e.g. `https://www.mysql.com/`, `https://www.oracle.com/`, `https://voltrondata.com/`). See commit 6e1f49e ("Ignore failing URLs in lychee").

This change adds `https://prestodb.io/` to `.lycheeignore`, grouped with the other DB-vendor homepages that block automated requests.

## Change

```diff
 https://www.mysql.com/
 https://www.oracle.com/
+https://prestodb.io/
```

## Verification

- Root cause isolated from the failing run logs (run `29818774484`): render passed; lychee reported exactly one error, the `prestodb.io` 403.
- lychee reads `.lycheeignore` by default; entries are matched against each URL (this is how the existing `github.com` / `mysql.com` entries exclude their URLs), so the added line excludes `https://prestodb.io/`.
- No content or render logic is changed, so the site output is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BRYo2D5L4wpgaTFTHH2B7

---
_Generated by [Claude Code](https://claude.ai/code/session_016BRYo2D5L4wpgaTFTHH2B7)_